### PR TITLE
Reverted retrieval of params and fixed launch file

### DIFF
--- a/launch/s3000_laser.launch
+++ b/launch/s3000_laser.launch
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="port" value="/dev/ttyUSB1" type="string"/>
+  <param name="~port" value="/dev/ttyUSB1" type="string"/>
   <node pkg="s3000_laser" type="s3000_laser" name="s3000_laser" output="screen" />
 </launch>

--- a/launch/s3000_laser.launch
+++ b/launch/s3000_laser.launch
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 <launch>
-  <param name="~port" value="/dev/ttyUSB1" type="string"/>
-  <node pkg="s3000_laser" type="s3000_laser" name="s3000_laser" output="screen" />
+  <arg name="port" default="/dev/ttyUSB1" />
+
+  <node pkg="s3000_laser" type="s3000_laser" name="s3000_laser" output="screen">
+    <param name="port" value="$(arg port)" type="string" />
+  </node>
 </launch>

--- a/src/s3000_laser.cc
+++ b/src/s3000_laser.cc
@@ -79,10 +79,10 @@ public:
   {
     ros::NodeHandle laser_node_handle(node_handle_, "s3000_laser");
 
+    private_node_handle_.param("port", port_, string("/dev/ttyUSB0"));
+    private_node_handle_.param<bool> ("publish_tf", publish_tf, false);
+    private_node_handle_.param("frame_id", frameid_, string("laser"));
     reading.header.frame_id = frameid_;
-    ros::param::param<std::string>("port", port_, string("/dev/ttyUSB0"));
-    ros::param::param<bool> ("publish_tf", publish_tf, false);
-    ros::param::param<std::string>("frame_id", frameid_, string("laser"));
 
     laser_data_pub_ = laser_node_handle.advertise<sensor_msgs::LaserScan>("scan", 100);
 


### PR DESCRIPTION
The previous merge #1 broke the driver (when launched using robot.launch from rockstead_bringup) due to the parameter retrieval changes. The port was not being retrieved from the launch file due to namespace issues. I've reverted back and updated the s3000_laser.launch file. Tested successfully on the robot. @abencz 
