### PR TITLE
Eliminate fixed rate loop, block on data receipt

### DIFF
--- a/external/SerialDevice/include/SerialDevice/SerialDevice.h
+++ b/external/SerialDevice/include/SerialDevice/SerialDevice.h
@@ -1,6 +1,6 @@
 /*
 *  Copyright (c) 2012, Robotnik Automation, SLL
-* 
+*
 *   This file is part of sick-s3000-ros-pkg.
 *
 *   sick-s3000-ros-pkg is free software: you can redistribute it and/or modify
@@ -23,14 +23,14 @@
  * \version 1.1
  * \date    2009
  *
- * \brief SerialDevice Class 
+ * \brief SerialDevice Class
  * (C) 2009 Robotnik Automation, SLL
  * Class to manage a serial port connection
 */
 
 #ifndef __SERIALDEV_H
 #define __SERIALDEV_H
-	
+
 #include <stdio.h>
 
 #define SERIAL_OK				0
@@ -45,35 +45,35 @@
 
 class SerialDevice{
 
-private:	
+private:
 	/**
 		* File descriptor
 	*/
 	int fd;
 	//
-	bool bReady;	
+	bool bReady;
 	//
-	unsigned char SendBuf[BUFFER];		
+	unsigned char SendBuf[BUFFER];
 	//
 	unsigned char RecBuf[BUFFER];
 	//Device's name
-	char cDevice[DEFAULT_SIZE_ARRAY];	
+	char cDevice[DEFAULT_SIZE_ARRAY];
 	//Parity for input and output: EVEN, ODD, NONE
-	char cParity[DEFAULT_SIZE_ARRAY];	
+	char cParity[DEFAULT_SIZE_ARRAY];
 	//BaudRate: 9600, 19200, 38400, 115200
 	int iBaudRate;
 	//Character size mask. Values are CS5, CS6, CS7, or CS8.
 	int iBitDataSize;
 	//Entrada canónica-> La entrada canónica es orientada a línea. Los caracteres se meten en un buffer hasta recibir un CR o LF.
 	bool bCanon;
-	
+
 public:
 	// Public Constructor
 	SerialDevice(void);
 	// Public Constructor
-	SerialDevice(const char *device, int baudrate,const char *parity, int datasize);	
+	SerialDevice(const char *device, int baudrate,const char *parity, int datasize);
 	// Public Destructor
-	~SerialDevice(void);	
+	~SerialDevice(void);
 	int OpenPort1(void);
 	int OpenPort2(void);
 	// Closes serial port
@@ -82,31 +82,31 @@ public:
 	// @return number of read bytes
 	int ReceiveMessage(char *msg);
 	// Send commands to the SerialDevice
-	// @return number of sent bytes 
+	// @return number of sent bytes
  	int SendMessage(char *msg, int length);
-	//int SendMessage(char *msg);	
+	//int SendMessage(char *msg);
 	int WritePort(char *chars, int length);
-	int WritePort(char *chars, int *written_bytes, int length);	// Importat del SerialDevice amb Component	
-	int ReadPort(char *result);	
+	int WritePort(char *chars, int *written_bytes, int length);	// Importat del SerialDevice amb Component
+	int ReadPort(char *result);
 	int ReadPort(char *result, int num_bytes);
 	int ReadPort(char *result, int *read_bytes, int num_bytes);  	// Importat del SerialDevice amb Component
 
-  bool BlockOnRead(int millis);
+	bool BlockOnRead(int millis);
 	//! Clean port buffer
-	int Flush();	
+	int Flush();
 	//! Returns opened device
 	char *GetDevice();
 	//! Sets the Canonical input. False by default
 	void SetCanonicalInput(bool value);
-	
+
 private:
-	
+
 	/**
 		* Set serial communication speed.
 		* Valid values: 9600, 19200, 38400, 115200
 		* @return SERIALDEV_OK
 		* @return SERIALDEV_ERROR
-	*/	
+	*/
 	int InitPort(void);
 	int GetBaud(void);
 	//!	Set serial communication speed.

--- a/external/SerialDevice/include/SerialDevice/SerialDevice.h
+++ b/external/SerialDevice/include/SerialDevice/SerialDevice.h
@@ -90,6 +90,8 @@ public:
 	int ReadPort(char *result);	
 	int ReadPort(char *result, int num_bytes);
 	int ReadPort(char *result, int *read_bytes, int num_bytes);  	// Importat del SerialDevice amb Component
+
+  bool BlockOnRead(int millis);
 	//! Clean port buffer
 	int Flush();	
 	//! Returns opened device

--- a/external/SerialDevice/src/SerialDevice.cc
+++ b/external/SerialDevice/src/SerialDevice.cc
@@ -1,6 +1,6 @@
 /*
 *  Copyright (c) 2012, Robotnik Automation, SLL
-* 
+*
 *   This file is part of sick-s3000-ros-pkg.
 *
 *   sick-s3000-ros-pkg is free software: you can redistribute it and/or modify
@@ -22,14 +22,14 @@
  * \version 1.1
  * \date    2009
  *
- * \brief SerialDevice Class 
+ * \brief SerialDevice Class
  * (C) 2009 Robotnik Automation, SLL
  * Class to manage a serial connection
 */
 
 #include "../include/SerialDevice/SerialDevice.h"
 #include <time.h>
-#include <string.h> 
+#include <string.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <unistd.h>  /* UNIX standard function definitions */
@@ -44,13 +44,13 @@
 /*! \fn SerialDevice::SerialDevice(void)
  	* Constructor by default
 */
-SerialDevice::SerialDevice(void){	
-	
+SerialDevice::SerialDevice(void){
+
 	strcpy(cDevice,DEFAULT_PORT);
 	strcpy(cParity,DEFAULT_PARITY);
 	iBaudRate=DEFAULT_TRANSFERRATE;
 	iBitDataSize = DEFAULT_DATA_SIZE;
-	bReady = false;	
+	bReady = false;
 	bCanon = false;
 }
 
@@ -58,15 +58,15 @@ SerialDevice::SerialDevice(void){
 /*! \fn SerialDevice::SerialDevice(void)
  	* Constructor by default
 */
-SerialDevice::SerialDevice(const char *device, int baudrate, const char *parity, int datasize){	
-	
+SerialDevice::SerialDevice(const char *device, int baudrate, const char *parity, int datasize){
+
 	strcpy(cDevice,device);
-	std::cout << "SerialDevice::SerialDevice: " << cDevice << " Parity= " << parity 
+	std::cout << "SerialDevice::SerialDevice: " << cDevice << " Parity= " << parity
 	<< " DataSize=" << datasize <<" BaudRate=" << baudrate << std::endl;
 	strcpy(cParity,parity);
 	iBaudRate=baudrate;
 	iBitDataSize = datasize;
-	bReady = false;	
+	bReady = false;
 	bCanon = false;
 }
 
@@ -115,62 +115,62 @@ int SerialDevice::InitPort() {
 	 		if(cfsetispeed( &options, iBaudRate ) < 0 || cfsetospeed( &options, iBaudRate ) < 0)
 			  {
 				// ROS_ERROR("failed to set serial baud rate");
-		  		return -1; 
+		  		return -1;
 	  		  }
                 break;
 		default:
 			cfsetispeed(&options, B19200);
 			cfsetospeed(&options, B19200);
 		break;
-	}	
+	}
 	// Enable the receiver and set local mode...
-	options.c_cflag |= CLOCAL | CREAD; 
+	options.c_cflag |= CLOCAL | CREAD;
 	options.c_cflag &= ~HUPCL;
-	// 
+	//
 	// PARITY
 	if(!strcmp(cParity, "none")){
-		//parity = NONE 
+		//parity = NONE
 		options.c_cflag &= ~PARENB;
-		options.c_cflag &= ~PARODD;  
+		options.c_cflag &= ~PARODD;
 		printf("SerialDevice::InitPort: Parity = none\n");
 	} else if(!strcmp(cParity, "even")){
-		//parity = EVEN 
-		options.c_cflag |= PARENB;  
+		//parity = EVEN
+		options.c_cflag |= PARENB;
 		printf("SerialDevice::InitPort: Parity = even\n");
 	} else if(!strcmp(cParity, "odd")){
 		options.c_cflag |= PARENB;
-		options.c_cflag |= PARODD; 
+		options.c_cflag |= PARODD;
 		printf("SerialDevice::InitPort: Parity = odd\n");
 	} else {
-		//parity = NONE 
+		//parity = NONE
 		options.c_cflag &= ~PARENB;
-		options.c_cflag &= ~PARODD; // NONE 
+		options.c_cflag &= ~PARODD; // NONE
 		printf("SerialDevice::InitPort: Parity = none\n");
 	}
-	
-	options.c_cflag &= ~CSTOPB;// 1 Stop bit	
+
+	options.c_cflag &= ~CSTOPB;// 1 Stop bit
 	options.c_cflag &= ~CSIZE;
 	//
 	// Character size
 	switch(iBitDataSize){
 		case 5:
-			options.c_cflag |= CS5;	
+			options.c_cflag |= CS5;
 			printf("SerialDevice::InitPort: Data size = CS5\n");
 		break;
 		case 6:
-			options.c_cflag |= CS6;	
+			options.c_cflag |= CS6;
 			printf("SerialDevice::InitPort: Data size = CS6\n");
 		break;
 		case 7:
-			options.c_cflag |= CS7;	
+			options.c_cflag |= CS7;
 			printf("SerialDevice::InitPort: Data size = CS7\n");
 		break;
 		case 8:
-			options.c_cflag |= CS8;	
+			options.c_cflag |= CS8;
 			printf("SerialDevice::InitPort: Data size = CS8\n");
 		break;
 		default:
-			options.c_cflag |= CS7;	
+			options.c_cflag |= CS7;
 			printf("SerialDevice::InitPort: Data size = CS7\n");
 		break;
 	}
@@ -180,7 +180,7 @@ ignbrk -brkint -ignpar -parmrk -inpck -istrip -inlcr -igncr -icrnl -ixon -ixoff 
 -opost -olcuc -ocrnl -onlcr -onocr -onlret -ofill -ofdel nl0 cr0 tab0 bs0 vt0 ff0
 -isig -icanon -iexten -echo -echoe -echok -echonl -noflsh -xcase -tostop -echoprt -echoctl -echoke
 	 */
-	options.c_cflag &= ~CRTSCTS;	//Disables hardware flow control	
+	options.c_cflag &= ~CRTSCTS;	//Disables hardware flow control
 
 	options.c_iflag |= IGNBRK;
 	options.c_iflag &= ~ICRNL;
@@ -194,7 +194,7 @@ ignbrk -brkint -ignpar -parmrk -inpck -istrip -inlcr -igncr -icrnl -ixon -ixoff 
 	options.c_lflag &= ~ECHOKE;
 	options.c_lflag &= ~ECHO;
 	options.c_lflag &= ~ECHOE;
-	// 
+	//
 	// Entrada canónica-> La entrada canónica es orientada a línea. Los caracteres se meten en un buffer hasta recibir un CR o LF.
 	if(bCanon)
 		options.c_lflag |= ICANON;
@@ -220,21 +220,21 @@ ignbrk -brkint -ignpar -parmrk -inpck -istrip -inlcr -igncr -icrnl -ixon -ixoff 
 int SerialDevice::OpenPort1(void){
 
 	fd = open(cDevice,  O_RDWR | O_NOCTTY);// | O_NDELAY);// | O_NONBLOCK)
-	
+
 	if(fd==-1){
 		std::cout << "SerialDevice::OpenPort: Error opening " << cDevice << " port" << std::endl;
-		return SERIAL_ERROR;  // invalid device file	
+		return SERIAL_ERROR;  // invalid device file
 	}else{
 		std::cout << "SerialDevice::OpenPort: " << cDevice << " opened properly" << std::endl;
 		//return SERIAL_OK;
 	}
-	
+
 	InitPort();		//TEST
-	
+
 	fcntl(fd,F_SETFL, FNDELAY);	//TEST
-	
+
 	bReady = true;
-	
+
 	return SERIAL_OK;
 }
 
@@ -244,19 +244,19 @@ int SerialDevice::OpenPort1(void){
 */
 int SerialDevice::OpenPort2(void){
 	struct termios newtio;
-		
+
 	fd = open(cDevice,  O_RDWR | O_NOCTTY | O_NDELAY | O_NONBLOCK);
 	if(fd==-1){
 		std::cout << "SerialDevice::OpenPort2: Error opening " << cDevice << " port" << std::endl;
-		return SERIAL_ERROR;  // invalid device file	
+		return SERIAL_ERROR;  // invalid device file
 	}//else{
 		//std::cout << "SerialDevice::OpenPort: " << cDevice << " opened properly" << std::endl;
 		//return SERIAL_OK;
 	//}
-	
+
 	// set up comm flags
 	memset(&newtio, 0,sizeof(newtio));
-	
+
 	switch(iBitDataSize)
 	{
 		case 5:
@@ -272,16 +272,16 @@ int SerialDevice::OpenPort2(void){
 			newtio.c_cflag = CS8 | CREAD;
 		break;
 		default:
-			//std::cout << "SerialDevice::OpenPort: unknown datasize (" << iBitDataSize << " bits) : setting default datasize ("<< DEFAULT_DATA_SIZE <<" bits)" << std::endl; 
+			//std::cout << "SerialDevice::OpenPort: unknown datasize (" << iBitDataSize << " bits) : setting default datasize ("<< DEFAULT_DATA_SIZE <<" bits)" << std::endl;
 			iBitDataSize = 8;
 			newtio.c_cflag = CS8 | CREAD;
 		break;
 	}
-	
+
 	newtio.c_iflag = INPCK;
 	newtio.c_oflag = 0;
 	newtio.c_lflag = 0;
-	
+
 	if(!strcmp(cParity,"even"))
 		newtio.c_cflag |= PARENB;//Even parity
 	else if(!strcmp(cParity,"odd"))
@@ -290,24 +290,24 @@ int SerialDevice::OpenPort2(void){
 		newtio.c_cflag &= ~PARODD;
 		newtio.c_cflag &= ~PARENB;
 	}
-	
+
 	newtio.c_lflag &= ~ICANON;	// TEST
-	
+
 	tcsetattr(fd, TCSANOW, &newtio);
 	tcflush(fd, TCIOFLUSH);
-		
+
 	if (SetTermSpeed(iBaudRate) == SERIAL_ERROR)
 	    return SERIAL_ERROR;
-	
+
 	// Make sure queue is empty
 	tcflush(fd, TCIOFLUSH);
 	usleep(1000);
 	tcflush(fd, TCIFLUSH);
-	
+
 	bReady = true;
-	
+
 	return SERIAL_OK;
-	
+
 }
 
 /*! \fn int SerialDevice::ClosePort(void)
@@ -315,7 +315,7 @@ int SerialDevice::OpenPort2(void){
 */
 int SerialDevice::ClosePort(void){
 	bReady = false;
-	
+
 	printf("SerialDevice::ClosePort: closing port %s\n", cDevice);
 	return close(fd);
 	//return SERIAL_OK;
@@ -328,9 +328,9 @@ int SerialDevice::ClosePort(void){
 	* @return SERIAL_ERROR if device is not ready
 */
 int SerialDevice::ReceiveMessage(char *msg)
-{	
+{
 	int n=0;
-	if(bReady) {		
+	if(bReady) {
 		// n= read(fd, msg, BUFFER);
 		n= ReadPort(msg);
 		//if(n>0)
@@ -346,13 +346,13 @@ int SerialDevice::ReceiveMessage(char *msg)
 /*!	\fn int SerialDevice::WritePort(char *chars, int length)
 	* @brief Sends commands to the Serial port
 	* @param chars as char*, string for sending
-	* @param length as int, length of the string	
+	* @param length as int, length of the string
 	* @return number of sent bytes
 */
 int SerialDevice::WritePort(char *chars, int length) {
 
-	//int len = strlen(chars);	
-	//chars[len] = 0x0d; // stick a <CR> after the command	
+	//int len = strlen(chars);
+	//chars[len] = 0x0d; // stick a <CR> after the command
 	//chars[len+1] = 0x00; // terminate the string properly
 
 	int n = write(fd, chars, length);//strlen(chars));
@@ -403,9 +403,15 @@ bool SerialDevice::BlockOnRead(int millis) {
   // Wait until we get a return value other than it being interrupted.
   while(1) {
     retval = select(fd+1, &rfds, NULL, NULL, &tv);
-    if (retval >= 1) return true;
-    if (retval = 0) return false;
-    if (retval = -1)
+    if (retval >= 1)
+    {
+      return true;
+    }
+    if (retval == 0)
+    {
+      return false;
+    }
+    if (retval == -1)
     {
       if (errno == EINTR)
       {
@@ -421,14 +427,14 @@ bool SerialDevice::BlockOnRead(int millis) {
 }
 
 /*!	\fn int SerialDevice::ReadPort(char *result)
-	* @brief Reads serial port 
+	* @brief Reads serial port
 	* @param result as char *, output buffer
 	* @return number of read bytes
 */
 int SerialDevice::ReadPort(char *result) {
 	int iIn = read(fd, result, 254);
 	//result[iIn-1] = 0x00;
-	
+
 	if (iIn < 0) {
 		if (errno == EAGAIN) {
 			//printf("SerialDevice::ReadPort: Read= %d, SERIAL EAGAIN ERROR, errno= %d\n",iIn, errno);
@@ -438,19 +444,19 @@ int SerialDevice::ReadPort(char *result) {
 			return -1;
 		}
 	}
-	//printf("SerialDevice::ReadPort: read %d bytes -> %s \n", iIn, result);	
+	//printf("SerialDevice::ReadPort: read %d bytes -> %s \n", iIn, result);
 	return iIn;
 }
 
 /*!	\fn int SerialDevice::ReadPort(char *result, int num_bytes)
-	* @brief Reads serial port 
+	* @brief Reads serial port
 	* @param result as char *, output buffer
 	* @return number of read bytes
 */
 int SerialDevice::ReadPort(char *result, int num_bytes) {
 	int iIn = read(fd, result, num_bytes);
 	//result[iIn-1] = 0x00;
-	
+
 	if (iIn < 0) {
 		if (errno == EAGAIN) {
 			//printf("SerialDevice::ReadPort: Read= %d, SERIAL EAGAIN ERROR, errno= %d\n",iIn, errno);
@@ -460,7 +466,7 @@ int SerialDevice::ReadPort(char *result, int num_bytes) {
 			return -1;
 		}
 	}
-	//printf("SerialDevice::ReadPort: read %d bytes -> %s \n", iIn, result);	
+	//printf("SerialDevice::ReadPort: read %d bytes -> %s \n", iIn, result);
 	return iIn;
 }
 
@@ -494,7 +500,7 @@ int SerialDevice::ReadPort(char *result, int *read_bytes, int num_bytes) {
 	*
 */
 int SerialDevice::GetBaud(void) {
-	
+
 	struct termios termAttr;
 	int inputSpeed = -1;
 	speed_t baudRate;
@@ -526,18 +532,18 @@ int SerialDevice::GetBaud(void) {
 */
 int SerialDevice::SendMessage(char *msg, int length){
 	int n=0;
-	
+
 	//n=write(fd, SendBuf, length);
 	if(bReady){
 	//printf("SerialDevice::SendMessage: strlen=%d\n", strlen(msg));
-		n = WritePort(msg, length);		
+		n = WritePort(msg, length);
 		return n;
 		//if(n==0){
 		//	printf("SerialDevice::SendMessage: Could not send command ");
 		//	return SERIAL_ERROR;
 		//}else
 		//	printf("SerialDevice::SendMessage: Transmited %d", n);
-		
+
 		//return SERIAL_OK;
 	}else	{
 		std::cout << "SerialDevice::SendMessage: Device is not ready" << std::endl;
@@ -554,7 +560,7 @@ int SerialDevice::SendMessage(char *msg, int length){
 int SerialDevice::SetTermSpeed(int speed){
 	struct termios term;
 	int term_speed;
-	
+
 	switch(speed){
 		case 9600:
 			term_speed = B9600;
@@ -576,7 +582,7 @@ int SerialDevice::SetTermSpeed(int speed){
 			//std::cout << "SerialDevice::SetTermSpeed: Unknown speed ("<< speed <<") speedL Setting default value ("<< term_speed <<")"<< std::endl;
 			break;
 	}
-	
+
 	switch(term_speed)
 	{
 		case B9600:
@@ -589,27 +595,27 @@ int SerialDevice::SetTermSpeed(int speed){
 				//std::cout << "SerialDevice::SetTermSpeed: Unable to get device attributes" << std::endl;
 				return SERIAL_ERROR;
 			}
-			
+
 		  	//cfmakeraw( &term );
 			if(cfsetispeed( &term, term_speed ) < 0 || cfsetospeed( &term, term_speed ) < 0)
 			{
 				///std::cout << "SerialDevice::SetTermSpeed: Failed to set serial baud rate" << std::endl;
 				return SERIAL_ERROR;
 			}
-			
+
 			if( tcsetattr( fd, TCSAFLUSH, &term ) < 0 )
 			{
-				//std::cout << "SerialDevice::SetTermSpeed: Unable to set device attributes" << std::endl;			
+				//std::cout << "SerialDevice::SetTermSpeed: Unable to set device attributes" << std::endl;
 				return SERIAL_ERROR;
 			}
 			//std::cout << "SerialDevice::SetTermSpeed: Communication rate changed to " << speed << std::endl;
 			return SERIAL_OK;
 		break;
-	
+
 	default:
 		//std::cout << "SerialDevice::SetTermSpeed: Unknown speed "<< speed << std::endl;
 		return SERIAL_ERROR;
-		
+
 	}
 	return SERIAL_OK;
 }
@@ -633,8 +639,8 @@ void SerialDevice::SetCanonicalInput(bool value){
 	bCanon = value;
 }
 
-/*	
-agvservicios:/robotrans# stty -F /dev/ttyS0 -a 
+/*
+agvservicios:/robotrans# stty -F /dev/ttyS0 -a
 
 speed 19200 baud; rows 0; columns 0; line = 0;
 intr = ^C; quit = ^\; erase = ^?; kill = ^U; eof = ^D; eol = <undef>;
@@ -651,16 +657,16 @@ ignbrk -brkint -ignpar -parmrk -inpck -istrip -inlcr -igncr -icrnl -ixon -ixoff
 
 agvservicios:/robotrans/src# stty -F /dev/ttyS1 -a
 speed 19200 baud; rows 0; columns 0; line = 0;
-intr = ^C; quit = ^\; erase = ^?; kill = ^U; eof = ^D; eol = <undef>; 
-eol2 = <undef>; swtch = <undef>; start = ^Q; stop = ^S; susp = ^Z; rprnt = ^R; 
+intr = ^C; quit = ^\; erase = ^?; kill = ^U; eof = ^D; eol = <undef>;
+eol2 = <undef>; swtch = <undef>; start = ^Q; stop = ^S; susp = ^Z; rprnt = ^R;
 
 werase = ^W; lnext = ^V; flush = ^O; min = 1; time = 5;
 parenb parodd cs7 -hupcl -cstopb cread clocal -crtscts
-ignbrk -brkint -ignpar -parmrk -inpck -istrip -inlcr -igncr -icrnl -ixon -ixoff 
--iuclc -ixany -imaxbel -iutf8 
+ignbrk -brkint -ignpar -parmrk -inpck -istrip -inlcr -igncr -icrnl -ixon -ixoff
+-iuclc -ixany -imaxbel -iutf8
 -opost -olcuc -ocrnl -onlcr -onocr -onlret -ofill -ofdel nl0 cr0 tab0 bs0 vt0 ff0
 
--isig icanon -iexten -echo -echoe -echok -echonl -noflsh -xcase -tostop -echoprt 
+-isig icanon -iexten -echo -echoe -echok -echonl -noflsh -xcase -tostop -echoprt
 -echoctl -echoke
 
 */

--- a/external/SerialDevice/src/SerialDevice.cc
+++ b/external/SerialDevice/src/SerialDevice.cc
@@ -390,6 +390,36 @@ int SerialDevice::WritePort(char *chars, int *written_bytes, int length) {
 	return SERIAL_OK;
 }
 
+bool SerialDevice::BlockOnRead(int millis) {
+  fd_set rfds;
+  struct timeval tv;
+  int retval;
+
+  FD_ZERO(&rfds);
+  FD_SET(fd, &rfds);
+  tv.tv_sec = 0;
+  tv.tv_usec = 1000 * millis;
+
+  // Wait until we get a return value other than it being interrupted.
+  while(1) {
+    retval = select(fd+1, &rfds, NULL, NULL, &tv);
+    if (retval >= 1) return true;
+    if (retval = 0) return false;
+    if (retval = -1)
+    {
+      if (errno == EINTR)
+      {
+        continue;
+      }
+      else
+      {
+        return false;
+      }
+    }
+
+  }
+}
+
 /*!	\fn int SerialDevice::ReadPort(char *result)
 	* @brief Reads serial port 
 	* @param result as char *, output buffer

--- a/include/sicks3000.h
+++ b/include/sicks3000.h
@@ -62,7 +62,7 @@ class SickS3000
 
     //! Read and process data
     int ReadLaser( sensor_msgs::LaserScan& scan_msg, bool& bValidData ); // public periodic function
-  
+
   private:
 
     // Process range data from laser
@@ -74,8 +74,6 @@ class SickS3000
 
     // Get the time (in ms)
     int64_t GetTime();
-
-    void SetScannerParams(sensor_msgs::LaserScan& scan, int data_count);
 
   protected:
 

--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,6 @@
   <depend>diagnostic_updater</depend>
   <depend>dynamic_reconfigure</depend>
   <depend>roscpp</depend>
-  <depend>self_test</depend>
   <depend>sensor_msgs</depend>
   <depend>std_srvs</depend>
 </package>

--- a/src/s3000_laser.cc
+++ b/src/s3000_laser.cc
@@ -27,7 +27,6 @@
 
 #include "sicks3000.h"   // s3000 driver from player (Toby Collet / Andrew Howard)
 #include "ros/time.h"
-#include "self_test/self_test.h"
 #include "diagnostic_updater/DiagnosticStatusWrapper.h"
 #include "diagnostic_updater/diagnostic_updater.h"
 #include "diagnostic_updater/publisher.h"
@@ -48,7 +47,6 @@ public:
 
   string port_;
 
-  self_test::TestRunner self_test_;
   diagnostic_updater::Updater diagnostic_;
 
   ros::NodeHandle node_handle_;
@@ -75,9 +73,7 @@ public:
     private_node_handle_.param("frame_id", frameid_, string("laser"));
     scan_msg_.header.frame_id = frameid_;
 
-    self_test_.add( "Connect Test", this, &s3000node::ConnectTest );
-
-    diagnostic_.add( "Laser S3000 Connection", this, &s3000node::deviceStatus );
+    diagnostic_.add( "connection status", this, &s3000node::deviceStatus );
 
     data_pub_.reset(new LaserScanDiagnosedPublisher(
           node_handle_.advertise<sensor_msgs::LaserScan>("scan", 1), diagnostic_,
@@ -170,7 +166,6 @@ public:
             getting_data_ = false;
           }
 
-          self_test_.checkTest();
           diagnostic_.update();
           ros::spinOnce();
         }

--- a/src/sicks3000.cc
+++ b/src/sicks3000.cc
@@ -40,12 +40,6 @@
 #define NACK    0x92
 #define CRC16_GEN_POL 0x8005
 
-//! Converts degrees to radians
-double DTOR(double val)
-{
-    return val*3.141592653589793/180.0;
-}
-
 /*! \fn SickS3000::SickS3000()
  *  \brief Public constructor
 */
@@ -105,25 +99,6 @@ int SickS3000::Close()
 {
   if (serial!=NULL) serial->ClosePort();
   return 0;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Set up scanner parameters based on number of results per scan
-void SickS3000::SetScannerParams(sensor_msgs::LaserScan& scan, int data_count)
-{
-  if (data_count == 761) // sicks3000
-  {
-    // Scan configuration
-    scan.angle_min  = static_cast<float> (DTOR(-95));
-    scan.angle_max  = static_cast<float> (DTOR(95));
-    scan.angle_increment =  static_cast<float> (DTOR(0.25));
-    scan.time_increment = (1.0/16.6) / 761.0;  //(((95.0+95.0)/0.25)+1.0);    // Freq 16.6Hz / 33.3Hz
-    scan.scan_time = (1.0/16.6);
-    scan.range_min  =  0;
-    scan.range_max  =  49;   // check ?
-
-    recognisedScanner = true;
-  }
 }
 
   int SickS3000::ReadLaser( sensor_msgs::LaserScan& scan, bool& bValidData ) // public periodic function
@@ -242,8 +217,6 @@ int SickS3000::ProcessLaserData(sensor_msgs::LaserScan& scan, bool& bValidData)
             rx_count -= (size + 4);
             continue;
           }
-          if (!recognisedScanner)
-            SetScannerParams(scan, data_count); // Set up parameters based on number of results.
 
           // Scan data, clear ranges, keep configuration
           scan.ranges.clear();


### PR DESCRIPTION
It's a bit of a jumble, as I also cleaned up diagnostics and some of initialization/reinitialization works, but the core of this change is that the read loop is now:
- use select() to block on data becoming available (100ms timeout)
- grab the laser's timestamp at this point.
- sleep for 40ms to wait for the buffer to fill up.
- read the contents of the buffer.
- process and publish laserscan.

If the timeout expires in the first step, or there's an fd error, it waits one second and reopens the connection. Recovery and diagnostics look good from testing with a VM on my laptop, with USB connect/disconnect as well as powering the laser down and up.

@servos @abencz to review.
