### PR TITLE
CORE-14893: Correct s3000_laser GPLv3 license

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@ s3000_ros
 =========
 
 Ros Hydro compatible (Catkinized) version of the S3000 Lidar ROS package from Robotnik Automation (GPLv3)
+
+License
+=======
+
+Licensed under GPLv3. Please checkout the `gitlab-devel` branch for the most recent mirror of our internal changes.


### PR DESCRIPTION
Provide a license section indicating where to find the most recent branch
mirroring our internal Gitlab repository.